### PR TITLE
Updated clipping to torch.nn.utils.clip_grad_norm_ (#403)

### DIFF
--- a/word_language_model/main.py
+++ b/word_language_model/main.py
@@ -159,7 +159,7 @@ def train():
         loss.backward()
 
         # `clip_grad_norm` helps prevent the exploding gradient problem in RNNs / LSTMs.
-        torch.nn.utils.clip_grad_norm(model.parameters(), args.clip)
+        torch.nn.utils.clip_grad_norm_(model.parameters(), args.clip)
         for p in model.parameters():
             p.data.add_(-lr, p.grad.data)
 


### PR DESCRIPTION
Description: Per the torch 0.4 documentation, torch.nn.utils.clip_grad_norm has been deprecated in favor of torch.nn.utils.clip_grad_norm_, this commit corrects the deprecated usage in word_language_model/main.py